### PR TITLE
Add css parser to recommended config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "eslint.validate": ["typescript"]
+  "eslint.validate": ["typescript", "css"]
 }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ export default defineConfig([
 ]);
 ```
 
+### Editor setup
+
+If you are using the ESLint plugin in VS Code add the following to your `settings.json` to enable `css` linting:
+
+```json
+{
+  "eslint.validate": ["css"]
+}
+```
+
 ### Rules
 
 | Name                                                                                 | Description                                                                                                                                               | `recommended` | autofix |

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -13,9 +13,11 @@ export default defineConfig([
     plugins: { js },
   },
   tseslint.configs.recommended,
-  perfectionist.configs["recommended-natural"],
   {
+    ...perfectionist.configs["recommended-natural"],
+    files: ["**/*.{js,mjs,cjs,ts,mts,cts}"],
     rules: {
+      ...perfectionist.configs["recommended-natural"].rules,
       "perfectionist/sort-objects": [
         "error",
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import css from "@eslint/css";
 import { ESLint, Linter } from "eslint";
 
 import {
@@ -34,6 +35,8 @@ export const configs: PluginConfigs = {
     },
     {
       files: ["**/*.css"],
+      language: "css/css",
+      plugins: { css },
       rules: {
         [`${pluginName}/sort-custom-properties`]: [
           "error",


### PR DESCRIPTION
Add editor setup to enable ESLint plugin for css files - without this the plugin does not show inline errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSS file linting support to the project configuration

* **Documentation**
  * Added Editor setup section documenting VS Code ESLint plugin configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->