### PR TITLE
Unexpected lines between same catergories

### DIFF
--- a/src/rules/sort-custom-properties.test.ts
+++ b/src/rules/sort-custom-properties.test.ts
@@ -549,6 +549,47 @@ const invalid: InvalidTestCase<MessageIds, Options>[] = [
 			}
 		`,
   },
+  {
+    code: `
+			:root {
+				--color-primary: #fff;
+
+				--spacing-sm-md: 0.6rem;
+
+
+				--spacing-xs: 0.25rem;
+
+				--spacing-sm: 0.5rem;
+
+
+				
+				--spacing-md: 0.75rem;
+
+				--spacing-lg: 1rem;
+
+				--spacing-xl: 1.5rem;
+
+				--spacing-2xl: 2rem;
+			}
+		`,
+    errors: [{ messageId: MESSAGE_IDS.unsortedCustomProperties }],
+    filename: "styles.css",
+    name: "Properties with same order pattern in wrong alphabetical order with pre-existing empty lines",
+    options: [{ emptyLineBetweenGroups: true }],
+    output: `
+			:root {
+				--spacing-2xl: 2rem;
+				--spacing-lg: 1rem;
+				--spacing-md: 0.75rem;
+				--spacing-sm: 0.5rem;
+				--spacing-sm-md: 0.6rem;
+				--spacing-xl: 1.5rem;
+				--spacing-xs: 0.25rem;
+
+				--color-primary: #fff;
+			}
+		`,
+  },
   // Nested blocks
   {
     code: `

--- a/src/rules/sort-custom-properties.ts
+++ b/src/rules/sort-custom-properties.ts
@@ -240,9 +240,16 @@ export const rule = createRule<Options, MessageIds>({
                 column: 1,
                 line: prop.node.loc.start.line,
               });
+
+              let endLine = prop.node.loc.end.line + 1;
+              const nextProp = currentBlockProperties[index + 1];
+              if (nextProp) {
+                endLine = nextProp.node.loc.start.line;
+              }
+
               const currentLineEnd = sourceCode.getIndexFromLoc({
                 column: 1,
-                line: prop.node.loc.end.line + 1,
+                line: endLine,
               });
 
               let replacement = "";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the dynamic calculation of text ranges during CSS custom properties reordering to prevent overlapping replacements and ensure accurate fix application.

* **Tests**
  * Added test case validating correct behavior when custom properties share the same order pattern but appear in incorrect alphabetical sequence, with empty lines between groups preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->